### PR TITLE
0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
       with:
         files: 'module.json'
       env:
+        name: 'vttes-to-foundry'
+        title: 'VTTES to Foundry'
         version: ${{steps.get_version.outputs.version-without-v}}
         url: https://github.com/${{github.repository}}
         manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ bower_components
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+*.code-workspace
 
 # misc
 .sass-cache

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
-    "name": "vttes-to-foundry",
-    "title": "VTTES to Foundry",
+    "name": "vttes-to-foundry-dev",
+    "title": "VTTES to Foundry DEV",
     "description": "",
     "version": "0.1.3",
     "library": "false",

--- a/scripts/lib/ActorImporter.js
+++ b/scripts/lib/ActorImporter.js
@@ -1,7 +1,7 @@
 import * as moduleLib from "./moduleLib.js";
 import ItemFormat from "./itemFormat.js";
 import * as spellLib from './spellLib.js'
-import {DND5E} from "../../../../systems/dnd5e/module/config.js"
+import { DND5E } from "../../../../systems/dnd5e/module/config.js"
 
 export default class ActorImporter {
 
@@ -20,6 +20,21 @@ export default class ActorImporter {
     async import(content) {
         this.content = content
         this.extractRepeatings()
+
+        // for (let idx = 0; idx < Object.keys(this.repeatingFeatures['attack']).length; idx++) {
+        //     const key = Object.keys(this.repeatingFeatures['attack'])[idx];
+        //     if (this.repeatingFeatures['attack'][key]['itemid']) {
+        //         var itemId = this.repeatingFeatures['attack'][key]['itemid'].current
+        //         console.log(this.repeatingFeatures['inventory'][itemId])
+        //         this.repeatingFeatures['inventory'][itemId]['hasattack'].current = 1
+        //         if (this.repeatingFeatures['inventory'][itemId]['itemattackid'].current.length == 0) {
+        //             this.repeatingFeatures['inventory'][itemId]['itemattackid'].current = key
+        //         } else if (this.repeatingFeatures['inventory'][itemId]['itemattackid'].current.indexOf(key) < 0) {
+        //             this.repeatingFeatures['inventory'][itemId]['itemattackid'].current += ',' + key
+        //         }
+        //         // console.log(this.repeatingFeatures['inventory'][itemId])
+        //     }
+        // }
     }
 
     getAbilities() {
@@ -155,21 +170,23 @@ export default class ActorImporter {
                 embedQueue: currentImport,
                 creationQueue: notCreated
             } = await this.embedFromRepeating(compendiums, key, options.transformAction, options)
-    
+
             moduleLib.vttLog(`${notCreated.length} items in ${key} were not found in compendiums of type ${key}`)
-    
+
             if (options.createAction) {
                 moduleLib.vttLog(`${key} items have create method. Iterating ...`)
                 for (let idx = 0; idx < notCreated.length; idx++) {
                     const notFoundItem = notCreated[idx];
                     var element = await options.createAction(notFoundItem, options)
-                    readyToImport.push(element)
+                    if (element != null) {
+                        readyToImport.push(element)
+                    }
                 }
             }
 
             readyToImport = [...readyToImport, ...currentImport]
         }
-        
+
 
         return readyToImport
     }
@@ -178,6 +195,7 @@ export default class ActorImporter {
         var newFeat = {
             name: feat.name.current,
             type: 'feat',
+            img: 'icons/commodities/tech/dial-meter-gauge-blue.webp',
             data: {
                 description: {
                     value: feat.description ? feat.description.current : ''
@@ -255,7 +273,10 @@ export default class ActorImporter {
                 var attackData = features['attack'][attackId]
                 if (attackData.versatile_alt && attackData.versatile_alt.current == 1) {
                     versatile = `${attackData.dmgbase.current} + @mod`
-                    item.data.properties.ver = true
+                    if (!newItem.data.properties) {
+                        newItem.data.properties = {}
+                    }
+                    newItem.data.properties.ver = true
                     continue
                 }
                 damageParts.push([
@@ -440,7 +461,7 @@ export default class ActorImporter {
                 max: t.max
             }
             if (propName == 'spelllevel') {
-                spells[id] = { level: t.current}
+                spells[id] = { level: t.current }
             }
         })
 
@@ -479,14 +500,20 @@ export default class ActorImporter {
         return compendiumEntries
     }
 
-    applySpellTranformation(content, objectToTransform, linkedFeature) {
+    applySpellTranformation(content, objectToTransform, linkedFeature, options) {
+        moduleLib.setItemGlobalOptions(options, objectToTransform);
+
         objectToTransform.data.preparation = spellLib.getPreparation(linkedFeature)
     }
 
-    
+
 
     createSpell(spellInfos, options) {
-        
+
+        if (!spellInfos.spellcastingtime) {
+            moduleLib.vttWarn(`Spell ${spellInfos.spellname.current} cannot be imported (reason : no spell casting time)`, true)
+            return null
+        }
 
         var activation = spellLib.getSpellActivation(spellInfos);
         var spellDuration = spellLib.getSpellDuration(spellInfos);
@@ -500,14 +527,16 @@ export default class ActorImporter {
         var save = spellLib.getSave(spellInfos);
         var school = spellLib.getSpellSchool(spellInfos);
         var preparation = spellLib.getPreparation(spellInfos)
+        var icon = spellLib.getIcon(spellInfos)
 
         var newSpell = {
             type: "spell",
             name: spellInfos.spellname.current,
+            img: icon,
             data: {
-                level: spellInfos.spelllevel.current == 'cantrip' ? 0 : parseInt(spellInfos.spelllevel.current),
+                level: !spellInfos.spelllevel || spellInfos.spelllevel.current == 'cantrip' ? 0 : parseInt(spellInfos.spelllevel.current),
                 description: {
-                    value: `${spellInfos.spelldescription.current}<p>${spellInfos.spelltarget.current}<p>${spellInfos.spellathigherlevels.current}`
+                    value: `${spellInfos.spelldescription.current}<p>${spellInfos.spelltarget ? spellInfos.spelltarget.current : ''}<p>${spellInfos.spellathigherlevels ? spellInfos.spellathigherlevels.current : ''}`
                 },
                 source: "Imported by VTTES2Foundry",
                 activation: activation,
@@ -521,7 +550,7 @@ export default class ActorImporter {
                 materials: materials,
                 save: save,
                 school: school,
-                preparation: preparation
+                preparation: preparation,
             }
         };
 
@@ -661,7 +690,7 @@ export default class ActorImporter {
     }
 
     getArmorsProficiencies(proficiencies) {
-        const nameTransform = function(name) {
+        const nameTransform = function (name) {
             if (name === 'shields') {
                 return DND5E.armorProficienciesMap['shield']
             }
@@ -673,7 +702,7 @@ export default class ActorImporter {
     }
 
     getWeaponsProficiencies(proficiencies) {
-        const nameTransform = function (name){
+        const nameTransform = function (name) {
             const lowerName = name.toLowerCase()
             if (lowerName === 'simple weapons') {
                 return 'sim'
@@ -694,8 +723,7 @@ export default class ActorImporter {
         }
         var values = keys.reduce((arr, curr) => {
             var profName = this.getAttribCurrent(curr + "_name").toLowerCase()
-            if (transform)
-            {
+            if (transform) {
                 profName = transform(profName)
             }
             arr.push(profName)
@@ -737,7 +765,7 @@ export default class ActorImporter {
         };
     }
 
-    noop() {}
+    noop() { }
 
     async embedFromRepeating(compendiums, repeatingKey, transformAction = this.noop, options = {
         keyName: 'name'
@@ -759,16 +787,18 @@ export default class ActorImporter {
                     moduleLib.vttWarn(`Current feat (${featId}) from key ${repeatingKey} has no name on property ${options.keyName}.`)
                     continue
                 }
+                const featNameForSearch = moduleLib.getNameForSearch(currFeat[options.keyName].current)
                 var found = false
 
                 for (let cpdIdx = 0; cpdIdx < compendiums.length; cpdIdx++) {
                     const compendium = compendiums[cpdIdx];
-                    const featNameForSearch = moduleLib.getNameForSearch(currFeat[options.keyName].current)
-                    var mfIndex = compendium.index.find(m => m.name.toLowerCase() === featNameForSearch)
+                    var mfIndex = compendium.index.find(m => m.name.toLowerCase() === featNameForSearch.name)
                     if (mfIndex) {
                         var feature = await compendium.getDocument(mfIndex._id)
                         var currObject = foundry.utils.deepClone(feature.toObject())
-                        transformAction(this.content, currObject, currFeat)
+
+                        var transformOptions = featNameForSearch.hasFlavorName ? { flavorName : currFeat[options.keyName].current } : {}
+                        transformAction(this.content, currObject, currFeat, transformOptions)
                         embedQueue.push(currObject)
                         found = true
 
@@ -782,7 +812,7 @@ export default class ActorImporter {
                     }
                 }
                 if (!found) {
-                    moduleLib.vttLog(`EmbedFromRepeating - ${repeatingKey} not found in compendium - Adding it to creation queue`)
+                    moduleLib.vttLog(`EmbedFromRepeating - ${currFeat[options.keyName].current} ${repeatingKey} not found in compendium - Adding it to creation queue`)
                     creationQueue.push(currFeat)
                 }
             }

--- a/scripts/lib/ActorImporter.js
+++ b/scripts/lib/ActorImporter.js
@@ -783,8 +783,8 @@ export default class ActorImporter {
             for (let featIndex = 0; featIndex < featureIds.length; featIndex++) {
                 const featId = featureIds[featIndex]
                 const currFeat = features[featId]
-                if (!currFeat[options.keyName]) {
-                    moduleLib.vttWarn(`Current feat (${featId}) from key ${repeatingKey} has no name on property ${options.keyName}.`)
+                if (!currFeat[options.keyName] || currFeat[options.keyName].current == '') {
+                    moduleLib.vttWarn(`Current feat (${featId}) from key ${repeatingKey} has no name on property ${options.keyName}.`, true)
                     continue
                 }
                 const featNameForSearch = moduleLib.getNameForSearch(currFeat[options.keyName].current)
@@ -812,7 +812,7 @@ export default class ActorImporter {
                     }
                 }
                 if (!found) {
-                    moduleLib.vttLog(`EmbedFromRepeating - ${currFeat[options.keyName].current} ${repeatingKey} not found in compendium - Adding it to creation queue`)
+                    moduleLib.vttLog(`EmbedFromRepeating - ${currFeat[options.keyName].current} not found in compendiums of type ${repeatingKey} - Adding it to creation queue`)
                     creationQueue.push(currFeat)
                 }
             }

--- a/scripts/lib/ActorImporter.js
+++ b/scripts/lib/ActorImporter.js
@@ -773,4 +773,34 @@ export default class ActorImporter {
         }
     }
 
+    getTokenSetup() {
+        var tokenContent = {
+            name: this.actor.name,
+            imgsrc: this.actor.img
+        }
+
+        if (this.content.character.defaulttoken && this.content.character.defaulttoken != '') {
+            tokenContent = JSON.parse(this.content.character.defaulttoken);
+        }
+
+        return {
+            name: tokenContent.name,
+            vision: true,
+            dimSight: tokenContent.night_vision_distance ?? this.darkvision,
+            img: tokenContent.imgsrc,
+            displayName: tokenContent.showname ? CONST.TOKEN_DISPLAY_MODES.ALWAYS : CONST.TOKEN_DISPLAY_MODES.NONE
+        }
+    }
+
+    // async updateToken(tokenInfos) {
+    //     var actorToken = this.actor.data.token;
+    //     await actorToken.update({
+    //         name: tokenInfos.name,
+    //         vision: true,
+    //         dimSight: tokenInfos.night_vision_distance ?? this.darkvision,
+    //         img: tokenInfos.imgsrc,
+    //         displayName: tokenInfos.showname ? CONST.TOKEN_DISPLAY_MODES.ALWAYS : CONST.TOKEN_DISPLAY_MODES.NONE
+    //     });
+    // }
+
 }

--- a/scripts/lib/NPCActor.js
+++ b/scripts/lib/NPCActor.js
@@ -22,18 +22,13 @@ export default class NPCActorImport extends ActorImporter {
         var spells = await this.getAndPrepareSpells()
 
         moduleLib.vttLog('Iterating on Features ...')
+        
         var embedFeaturesQueue = []
         var {
             embedQueue: embedFeaturesQueue,
             creationQueue: creationFeaturesQueue
         } = await this.embedMonsterFeatures(monsterFeatures)
-
-        // moduleLib.vttLog('Iterating on Actions ...')
-        // var embedActionsQueue = []
-        // var {
-        //     embedQueue: embedActionsQueue,
-        //     creationQueue: creationActionQueue
-        // } = await this.embedFromRepeating([monsterFeatures, ...items], 'npcaction', this.updateDamage)
+        this.setDarkvision(embedFeaturesQueue)
 
         var embedActionsQueue = await this.embedFromCompendiums(['npcaction', 'weapon'], 'npcaction', {
             transformAction: this.updateDamage,
@@ -42,7 +37,6 @@ export default class NPCActorImport extends ActorImporter {
 
         var allItemsToCreate = [...embedFeaturesQueue, ...embedActionsQueue, ...spells];
 
-        var darkvision = this.getDarkvision(embedFeaturesQueue)
 
         await this.actor.createEmbeddedDocuments("Item", allItemsToCreate);
 

--- a/scripts/lib/NPCActor.js
+++ b/scripts/lib/NPCActor.js
@@ -22,7 +22,7 @@ export default class NPCActorImport extends ActorImporter {
         var spells = await this.getAndPrepareSpells()
 
         moduleLib.vttLog('Iterating on Features ...')
-        
+
         var embedFeaturesQueue = []
         var {
             embedQueue: embedFeaturesQueue,
@@ -50,6 +50,7 @@ export default class NPCActorImport extends ActorImporter {
         var alignment = typeInfos.substring(comaIndex + 1)
         var size = moduleLib.getSizeCode(typeInfos.substring(0, spaceIndex).toLowerCase())
         var type = typeInfos.substring(spaceIndex, comaIndex)
+        var tokenContent = this.getTokenSetup()
 
         this.actor.update({
             name: content.character.name,
@@ -77,8 +78,11 @@ export default class NPCActorImport extends ActorImporter {
                         custom: this.getAttribCurrent("npc_vulnerabilities")
                     }
                 }
-            }
+            },
+            token: tokenContent
         })
+
+
 
     }
 

--- a/scripts/lib/PCActor.js
+++ b/scripts/lib/PCActor.js
@@ -64,7 +64,9 @@ export default class PCActorImport extends ActorImporter {
         return spellKeys;
     }
 
-    applyItemTranformation(content, objectToTransform, linkedFeature) {
+    applyItemTranformation(content, objectToTransform, linkedFeature, options) {
+        moduleLib.setItemGlobalOptions(options, objectToTransform);
+        
         if (objectToTransform.type == 'equipment' || objectToTransform.type == 'weapon'){
             objectToTransform.data.equipped = linkedFeature['equipped'] ? linkedFeature['equipped'].current == 1 : true 
         }
@@ -240,3 +242,5 @@ export default class PCActorImport extends ActorImporter {
         }, []);
     }
 }
+
+

--- a/scripts/lib/PCActor.js
+++ b/scripts/lib/PCActor.js
@@ -66,7 +66,7 @@ export default class PCActorImport extends ActorImporter {
 
     applyItemTranformation(content, objectToTransform, linkedFeature, options) {
         moduleLib.setItemGlobalOptions(options, objectToTransform);
-        
+
         if (objectToTransform.type == 'equipment' || objectToTransform.type == 'weapon'){
             objectToTransform.data.equipped = linkedFeature['equipped'] ? linkedFeature['equipped'].current == 1 : true 
         }
@@ -157,7 +157,7 @@ export default class PCActorImport extends ActorImporter {
                     },
                     hp: this.getHp(),
                     init: {
-                        mod: this.getAttribCurrentInt("initiative_bonus"),
+                        value: this.getAttribCurrentInt("initmod"),
                     },
                     movement: {
                         burrow: 0,

--- a/scripts/lib/PCActor.js
+++ b/scripts/lib/PCActor.js
@@ -17,19 +17,21 @@ export default class PCActorImport extends ActorImporter {
         var traits = await this.embedFromCompendiums(['feat'], 'traits', {
             createAction: this.createFeat
         })
+        this.setDarkvision(traits);
+
         var inventory = await this.embedFromCompendiums(['equipment'], 'inventory', {
             keyName: 'itemname',
             createAction: this.createItem,
             features: this.repeatingFeatures,
             transformAction: this.applyItemTranformation
         })
+
         var spells = await this.getAndPrepareSpells();
 
         await this.setClasses();
 
-        var darkvision = this.getDarkvision(traits);
         var size = moduleLib.getSizeCode(this.getAttribCurrent("size"))
-        await this.updatePCActorSheet(darkvision, size, abilities);
+        await this.updatePCActorSheet(this.darkvision, size, abilities);
 
         this.applyProficiencies(inventory);
 
@@ -39,23 +41,23 @@ export default class PCActorImport extends ActorImporter {
 
         if (this.content.character.defaulttoken && this.content.character.defaulttoken != '') {
             var tokenInfos = JSON.parse(this.content.character.defaulttoken);
-            await this.updateToken(tokenInfos, darkvision);
+            await this.updateToken(tokenInfos, this.darkvision);
         } else {
             await this.updateToken({
                 name: this.actor.name,
                 imgsrc: this.actor.img
-            }, darkvision);
+            });
         }
 
         await this.actor.longRest({dialog: false, chat: false})
     }
 
-    async updateToken(tokenInfos, darkvision) {
+    async updateToken(tokenInfos) {
         var actorToken = this.actor.data.token;
         await actorToken.update({
             name: tokenInfos.name,
             vision: true,
-            dimSight: tokenInfos.night_vision_distance ?? darkvision,
+            dimSight: tokenInfos.night_vision_distance ?? this.darkvision,
             img: tokenInfos.imgsrc,
             displayName: tokenInfos.showname ? CONST.TOKEN_DISPLAY_MODES.ALWAYS : CONST.TOKEN_DISPLAY_MODES.NONE
         });

--- a/scripts/lib/PCActor.js
+++ b/scripts/lib/PCActor.js
@@ -31,6 +31,7 @@ export default class PCActorImport extends ActorImporter {
         await this.setClasses();
 
         var size = moduleLib.getSizeCode(this.getAttribCurrent("size"))
+
         await this.updatePCActorSheet(this.darkvision, size, abilities);
 
         this.applyProficiencies(inventory);
@@ -38,30 +39,12 @@ export default class PCActorImport extends ActorImporter {
         var allItemsToCreate = [...inventory, ...traits, ...spells];
         await this.actor.createEmbeddedDocuments("Item", allItemsToCreate);
 
-
-        if (this.content.character.defaulttoken && this.content.character.defaulttoken != '') {
-            var tokenInfos = JSON.parse(this.content.character.defaulttoken);
-            await this.updateToken(tokenInfos, this.darkvision);
-        } else {
-            await this.updateToken({
-                name: this.actor.name,
-                imgsrc: this.actor.img
-            });
-        }
+        await this.getTokenSetup();
 
         await this.actor.longRest({dialog: false, chat: false})
     }
 
-    async updateToken(tokenInfos) {
-        var actorToken = this.actor.data.token;
-        await actorToken.update({
-            name: tokenInfos.name,
-            vision: true,
-            dimSight: tokenInfos.night_vision_distance ?? this.darkvision,
-            img: tokenInfos.imgsrc,
-            displayName: tokenInfos.showname ? CONST.TOKEN_DISPLAY_MODES.ALWAYS : CONST.TOKEN_DISPLAY_MODES.NONE
-        });
-    }
+    
 
     applyItemTranformation(content, objectToTransform, linkedFeature) {
         if (objectToTransform.type == 'equipment' || objectToTransform.type == 'weapon'){
@@ -140,6 +123,7 @@ export default class PCActorImport extends ActorImporter {
         var tools = this.getToolProficiencies()
 
         var proficiencies = this.getGlobalProficiencies()
+        var tokenContent = this.getTokenSetup()
 
         await this.actor.update({
             name: this.content.character.name,
@@ -226,7 +210,8 @@ export default class PCActorImport extends ActorImporter {
                         custom: tools.join(';')
                     }
                 }
-            }
+            },
+            token: tokenContent
         });
     }
 

--- a/scripts/lib/moduleLib.js
+++ b/scripts/lib/moduleLib.js
@@ -6,6 +6,7 @@ const LOCAL_CONFIG = {
 
 const SOURCE_MESSAGE = 'Imported by vttes to Foundry'
 
+
 const getFolderPath = function() {
     if (LOCAL_CONFIG.environment === 'dev') {
         return 'modules/vttes-to-foundry-dev/'
@@ -208,8 +209,21 @@ export {vttLog, vttWarn, vttError, getAttackTypeFromWeaponType, capitalizeFirstL
     getSizeCode, getArmorTypeAndDexLimit, getFolderPath, SOURCE_MESSAGE, getAttackType, WEAPON_PROPERTIES, getArmorType, TIME_TRANSLATE}
 
 export function getNameForSearch(itemName) {
-    return itemName.toLowerCase()
+
+    var output = {name: itemName.toLowerCase(), hasFlavorName: false}
+    const searchRegex = /\([\w\s]*\)/g;
+    var match
+
+    if (match = searchRegex.exec(itemName)) {        
+        match.forEach(m => output = {name: m.substring(1, m.length - 1).toLowerCase(), hasFlavorName: true} )
+    }
+
+    return output
 }
 
-
+export function setItemGlobalOptions(options, objectToTransform) {
+    if (options && options.flavorName) {
+        objectToTransform.name = options.flavorName;
+    }
+}
 

--- a/scripts/lib/moduleLib.js
+++ b/scripts/lib/moduleLib.js
@@ -210,8 +210,8 @@ export {vttLog, vttWarn, vttError, getAttackTypeFromWeaponType, capitalizeFirstL
 
 export function getNameForSearch(itemName) {
 
-    var output = {name: itemName.toLowerCase(), hasFlavorName: false}
-    const searchRegex = /\([\w\s]*\)/g;
+    var output = {name: itemName    .toLowerCase(), hasFlavorName: false}
+    const searchRegex = /\([\S\s]*\)/g;
     var match
 
     if (match = searchRegex.exec(itemName)) {        

--- a/scripts/lib/moduleLib.js
+++ b/scripts/lib/moduleLib.js
@@ -1,4 +1,3 @@
-
 const LOG_PREFIX = 'VTTES2FVTT'
 
 const LOCAL_CONFIG = {
@@ -50,6 +49,8 @@ const capitalizeFirstLetterOfEveryWord = function(string) {
 }
 
 const capitalizeFirstLetter = function (string) {
+    if (!string || string.length == 0)
+        return string
     return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
@@ -130,6 +131,21 @@ const WEAPON_TYPE_TO_ACTION = {
     "Other": "other"
 }
 
+export const SPELL_TYPE_TO_ACTION = {
+    "Ranged"    : "rsak",
+    "Melee"     : "msak",
+    "Other"     : "other"
+}
+
+export const ABILITIES = {
+    'Strength'      : 'str',
+    'Dexterity'     : 'dex',
+    'Constitution'  : 'con',
+    'Intelligence'  : 'int',
+    'Wisdom'        : 'wis',
+    'Charisma'      : 'cha'
+}
+
 const WEAPON_TYPES = 
     {
         "Adamantite" : "ada",
@@ -152,28 +168,44 @@ const WEAPON_TYPES =
       }
 
 const WEAPON_PROPERTIES = {
-"ada": "Adamantite",
-"amm": "Ammunition",
-"fin": "Finesse",
-"fir": "Firearm",
-"foc": "Focus",
-"hvy": "Heavy",
-"lgt": "Light",
-"lod": "Loading",
-"mgc": "Magical",
-"rch": "Reach",
-"rel": "Reload",
-"ret": "Returning",
-"sil": "Silvered",
-"spc": "Special",
-"thr": "Thrown",
-"two": "Two-Handed",
-"ver": "Versatile"
-};
+    "ada": "Adamantite",
+    "amm": "Ammunition",
+    "fin": "Finesse",
+    "fir": "Firearm",
+    "foc": "Focus",
+    "hvy": "Heavy",
+    "lgt": "Light",
+    "lod": "Loading",
+    "mgc": "Magical",
+    "rch": "Reach",
+    "rel": "Reload",
+    "ret": "Returning",
+    "sil": "Silvered",
+    "spc": "Special",
+    "thr": "Thrown",
+    "two": "Two-Handed",
+    "ver": "Versatile"
+    };
 
+const TIME_TRANSLATE = {
+    'instantaneous' : 'inst',
+    'hours' : 'hour',
+    'minutes' : 'minute'
+}
+
+export const SPELL_SCHOOLS = {
+    'abjuration' : 'abj',
+    'conjuration' : 'con',
+    'divination' : 'div',
+    'enchantment' : 'enc',
+    'evocation' : 'evo',
+    'illusion' : 'ill',
+    'necromancy' : 'nec',
+    'transmutation' : 'trs'
+}
 
 export {vttLog, vttWarn, vttError, getAttackTypeFromWeaponType, capitalizeFirstLetter, getAttackRange, capitalizeFirstLetterOfEveryWord,
-    getSizeCode, getArmorTypeAndDexLimit, getFolderPath, SOURCE_MESSAGE, getAttackType, WEAPON_PROPERTIES, getArmorType}
+    getSizeCode, getArmorTypeAndDexLimit, getFolderPath, SOURCE_MESSAGE, getAttackType, WEAPON_PROPERTIES, getArmorType, TIME_TRANSLATE}
 
 export function getNameForSearch(itemName) {
     return itemName.toLowerCase()

--- a/scripts/lib/spellLib.js
+++ b/scripts/lib/spellLib.js
@@ -1,0 +1,177 @@
+import * as moduleLib from "./moduleLib.js";
+
+
+    export function getSpellActivation (spellInfos) {
+        var activation = {
+            type: '',
+            cost: 0,
+            condition: ''
+        }
+
+        var castingTime = spellInfos.spellcastingtime.current
+
+        var commaIdx = castingTime.indexOf(',')
+        if ( commaIdx >= 0) {
+            activation.condition = castingTime.substring(commaIdx + 1)
+            var timeRange = castingTime.substring(0, commaIdx).split(' ')
+            activation.cost = timeRange[0]
+            activation.type = timeRange[1]
+        } else {
+            var timeRange = castingTime.split(' ')
+            activation.cost = timeRange[0]
+            activation.type = timeRange[1]
+        }
+
+        return activation
+    }
+
+    const getSpellDuration = function(spellInfos) {
+        var duration = {
+            value: 0,
+            units: ''
+        }
+
+        if (!spellInfos.spellduration) {
+            return duration
+        }
+
+        var durationTime = spellInfos.spellduration.current
+
+        if (durationTime.toLowerCase().indexOf('up to') >= 0) {
+            durationTime = durationTime.substring(6)
+        }
+
+        var parts = durationTime.split(' ')
+        if (moduleLib.TIME_TRANSLATE[parts[1]]){
+            duration.units = moduleLib.TIME_TRANSLATE[parts[1]]
+        } else {
+            duration.units = parts[1]
+        }
+        
+        duration.value = parseInt(parts[0])
+
+
+        return duration
+    }
+
+    const getSpellRange = function(spellInfos) {
+        var range = {}
+        if (['Self', 'Touch'].indexOf(spellInfos.spellrange.current) < 0) {
+            var rangeData = spellInfos.spellrange.current.split(' ');
+            range.value = parseInt(rangeData[0]);
+            range.long = 0;
+            range.units = rangeData[1] == 'feet' ? 'ft' : rangeData[1];
+        } else {
+            range.units = spellInfos.spellrange.current.toLowerCase();
+        }
+        return range
+    }
+
+    const getSpellTarget = function(spellInfos) {
+        return spellInfos.spelltarget.current
+    }
+
+    export function getActionType(spellInfos) {
+        if (moduleLib.SPELL_TYPE_TO_ACTION[spellInfos.spellattack.current]) {
+            return moduleLib.SPELL_TYPE_TO_ACTION[spellInfos.spellattack.current]
+        }
+        
+        if (spellInfos.spellattack.current == '') {
+            if (spellInfos.spelldamage.current != '') {
+                return 'save'
+            }
+            if (spellInfos.spellhealing.current != '') {
+                return 'heal'
+            }
+        }
+
+        return null
+    }
+
+    export function getDamages(spellInfos) {
+        var damage = {
+            parts: [],
+            versatile: ''
+        }
+
+        var hasMod = spellInfos.spelldmgmod.current.toLowerCase() == 'yes'
+
+        if (spellInfos.spellhealing && spellInfos.spellhealing.current != '') {
+            var healingPart = `${spellInfos.spellhealing.current}${hasMod ? ' +@mod' : ''}`
+            damage.parts.push([ healingPart, 'healing'])
+        }
+
+        if (spellInfos.spelldamage && spellInfos.spelldamage.current != '') {
+            var damagePart = `${spellInfos.spelldamage.current}${hasMod ? ' +@mod' : ''}`
+            damage.parts.push([ damagePart, spellInfos.spelldamagetype.current.toLowerCase()])
+        }
+
+        if (spellInfos.spelldamage2 && spellInfos.spelldamage2.current != '') {
+            var damagePart = `${spellInfos.spelldamage2.current}${hasMod ? ' +@mod' : ''}`
+            damage.parts.push([ spellInfos.spelldamage2.current + hasMod ? ' + @mod' : '', spellInfos.spelldamagetype2.current.toLowerCase()])
+        }
+
+        return damage
+    }
+
+    export function getScaling(spellInfos) {
+        var scaling = {
+            mode: '',
+            formula: ''
+        }
+
+        if (spellInfos.spelllevel.current == 'cantrip') {
+            scaling.mode = 'cantrip'
+        } else {
+            scaling.mode = 'level'
+            if (spellInfos.spellhldie.current.indexOf('.') >= 0) {
+                var constant = parseFloat(spellInfos.spellhldie.current)
+                var formulaMult = Math.round(1 / constant)
+                scaling.formula = 'floor((@item.level - 1)/' + formulaMult + ')'+ spellInfos.spellhldietype.current
+            } else {
+                scaling.formula = spellInfos.spellhldie.current + spellInfos.spellhldietype.current
+            }
+        }
+
+        return scaling
+    }
+
+    export function getComponents(spellInfos) {
+        var component = {
+            vocal: spellInfos.spellcomp_v.current.length > 0,
+            somatic: spellInfos.spellcomp_s.current.length > 0,
+            material: spellInfos.spellcomp_m.current.length > 0,
+            ritual: spellInfos.spellritual.current.length > 0,
+            concentration: spellInfos.spellconcentration.current.length > 0,
+            value: spellInfos.spellcomp_materials.current
+        }
+
+        return component
+    }
+
+    export function getMaterials(spellInfos) {
+        var materials = {
+            consumed: false,
+            cost: 0,
+            supply: 0,
+            value: spellInfos.spellcomp_materials.current
+        }
+        
+        return materials
+    }
+
+    export function getSave(spellInfos) {
+        var save = {
+            ability: moduleLib.ABILITIES[spellInfos.spellsave.current],
+            dc: null,
+            scaling: spellInfos.spell_ability.current
+        }
+
+        return save
+    }
+
+    export function getSpellSchool(spellInfos) {
+        return moduleLib.SPELL_SCHOOLS[spellInfos.spellschool.current]
+    }
+
+export {getSpellTarget, getSpellRange, getSpellDuration}

--- a/scripts/lib/spellLib.js
+++ b/scripts/lib/spellLib.js
@@ -85,7 +85,7 @@ import * as moduleLib from "./moduleLib.js";
             }
         }
 
-        return null
+        return 'util'
     }
 
     export function getDamages(spellInfos) {
@@ -172,6 +172,33 @@ import * as moduleLib from "./moduleLib.js";
 
     export function getSpellSchool(spellInfos) {
         return moduleLib.SPELL_SCHOOLS[spellInfos.spellschool.current]
+    }
+
+    export function isPactMagic(spellInfos) {
+        return spellInfos.spellclass.current.toLowerCase().indexOf('warlock') >= 0;
+    }
+
+    export function getPreparation(spellInfos) {
+        var preparation = {
+            mode: 'prepared',
+            prepared: false
+        }
+
+        if (this.isPactMagic(spellInfos) && spellInfos.spelllevel.current != 'cantrip') {
+            preparation = {
+                mode: 'pact',
+                prepared: true
+            }
+        }
+
+        if (spellInfos.innate && spellInfos.innate.current.length > 0) {
+            preparation = {
+                mode: 'innate',
+                prepared: true
+            }
+        }
+
+        return preparation
     }
 
 export {getSpellTarget, getSpellRange, getSpellDuration}

--- a/scripts/lib/spellLib.js
+++ b/scripts/lib/spellLib.js
@@ -1,81 +1,82 @@
 import * as moduleLib from "./moduleLib.js";
 
 
-    export function getSpellActivation (spellInfos) {
-        var activation = {
-            type: '',
-            cost: 0,
-            condition: ''
-        }
-
-        var castingTime = spellInfos.spellcastingtime.current
-
-        var commaIdx = castingTime.indexOf(',')
-        if ( commaIdx >= 0) {
-            activation.condition = castingTime.substring(commaIdx + 1)
-            var timeRange = castingTime.substring(0, commaIdx).split(' ')
-            activation.cost = timeRange[0]
-            activation.type = timeRange[1]
-        } else {
-            var timeRange = castingTime.split(' ')
-            activation.cost = timeRange[0]
-            activation.type = timeRange[1]
-        }
-
-        return activation
+export function getSpellActivation(spellInfos) {
+    var activation = {
+        type: '',
+        cost: 0,
+        condition: ''
     }
 
-    const getSpellDuration = function(spellInfos) {
-        var duration = {
-            value: 0,
-            units: ''
-        }
+    var castingTime = spellInfos.spellcastingtime.current
 
-        if (!spellInfos.spellduration) {
-            return duration
-        }
+    var commaIdx = castingTime.indexOf(',')
+    if (commaIdx >= 0) {
+        activation.condition = castingTime.substring(commaIdx + 1)
+        var timeRange = castingTime.substring(0, commaIdx).split(' ')
+        activation.cost = timeRange[0]
+        activation.type = timeRange[1]
+    } else {
+        var timeRange = castingTime.split(' ')
+        activation.cost = timeRange[0]
+        activation.type = timeRange[1]
+    }
 
-        var durationTime = spellInfos.spellduration.current
+    return activation
+}
 
-        if (durationTime.toLowerCase().indexOf('up to') >= 0) {
-            durationTime = durationTime.substring(6)
-        }
+const getSpellDuration = function (spellInfos) {
+    var duration = {
+        value: 0,
+        units: ''
+    }
 
-        var parts = durationTime.split(' ')
-        if (moduleLib.TIME_TRANSLATE[parts[1]]){
-            duration.units = moduleLib.TIME_TRANSLATE[parts[1]]
-        } else {
-            duration.units = parts[1]
-        }
-        
-        duration.value = parseInt(parts[0])
-
-
+    if (!spellInfos.spellduration) {
         return duration
     }
 
-    const getSpellRange = function(spellInfos) {
-        var range = {}
-        if (['Self', 'Touch'].indexOf(spellInfos.spellrange.current) < 0) {
-            var rangeData = spellInfos.spellrange.current.split(' ');
-            range.value = parseInt(rangeData[0]);
-            range.long = 0;
-            range.units = rangeData[1] == 'feet' ? 'ft' : rangeData[1];
-        } else {
-            range.units = spellInfos.spellrange.current.toLowerCase();
-        }
-        return range
+    var durationTime = spellInfos.spellduration.current
+
+    if (durationTime.toLowerCase().indexOf('up to') >= 0) {
+        durationTime = durationTime.substring(6)
     }
 
-    const getSpellTarget = function(spellInfos) {
-        return spellInfos.spelltarget.current
+    var parts = durationTime.split(' ')
+    if (moduleLib.TIME_TRANSLATE[parts[1]]) {
+        duration.units = moduleLib.TIME_TRANSLATE[parts[1]]
+    } else {
+        duration.units = parts[1]
     }
 
-    export function getActionType(spellInfos) {
+    duration.value = parseInt(parts[0])
+
+
+    return duration
+}
+
+const getSpellRange = function (spellInfos) {
+    var range = {}
+    if (['Self', 'Touch'].indexOf(spellInfos.spellrange.current) < 0) {
+        var rangeData = spellInfos.spellrange.current.split(' ');
+        range.value = parseInt(rangeData[0]);
+        range.long = 0;
+        range.units = rangeData[1] == 'feet' ? 'ft' : rangeData[1];
+    } else {
+        range.units = spellInfos.spellrange.current.toLowerCase();
+    }
+    return range
+}
+
+const getSpellTarget = function (spellInfos) {
+    return spellInfos.spelltarget ? spellInfos.spelltarget.current : ''
+}
+
+export function getActionType(spellInfos) {
+    if (spellInfos.spellattack) {
         if (moduleLib.SPELL_TYPE_TO_ACTION[spellInfos.spellattack.current]) {
             return moduleLib.SPELL_TYPE_TO_ACTION[spellInfos.spellattack.current]
         }
-        
+
         if (spellInfos.spellattack.current == '') {
             if (spellInfos.spelldamage.current != '') {
                 return 'save'
@@ -84,121 +85,167 @@ import * as moduleLib from "./moduleLib.js";
                 return 'heal'
             }
         }
-
-        return 'util'
     }
 
-    export function getDamages(spellInfos) {
-        var damage = {
-            parts: [],
-            versatile: ''
-        }
+    return 'util'
+}
 
+export function getDamages(spellInfos) {
+    var damage = {
+        parts: [],
+        versatile: ''
+    }
+
+    if (spellInfos.spelldmgmod) {
         var hasMod = spellInfos.spelldmgmod.current.toLowerCase() == 'yes'
 
-        if (spellInfos.spellhealing && spellInfos.spellhealing.current != '') {
+        if (isHealingSpell(spellInfos)) {
             var healingPart = `${spellInfos.spellhealing.current}${hasMod ? ' +@mod' : ''}`
-            damage.parts.push([ healingPart, 'healing'])
+            damage.parts.push([healingPart, 'healing'])
         }
 
-        if (spellInfos.spelldamage && spellInfos.spelldamage.current != '') {
+        if (hasDamage(spellInfos)) {
             var damagePart = `${spellInfos.spelldamage.current}${hasMod ? ' +@mod' : ''}`
-            damage.parts.push([ damagePart, spellInfos.spelldamagetype.current.toLowerCase()])
+            damage.parts.push([damagePart, spellInfos.spelldamagetype.current.toLowerCase()])
         }
 
         if (spellInfos.spelldamage2 && spellInfos.spelldamage2.current != '') {
             var damagePart = `${spellInfos.spelldamage2.current}${hasMod ? ' +@mod' : ''}`
-            damage.parts.push([ spellInfos.spelldamage2.current + hasMod ? ' + @mod' : '', spellInfos.spelldamagetype2.current.toLowerCase()])
+            damage.parts.push([spellInfos.spelldamage2.current + hasMod ? ' + @mod' : '', spellInfos.spelldamagetype2.current.toLowerCase()])
         }
-
-        return damage
     }
 
-    export function getScaling(spellInfos) {
-        var scaling = {
-            mode: '',
-            formula: ''
-        }
+    return damage
+}
 
-        if (spellInfos.spelllevel.current == 'cantrip') {
-            scaling.mode = 'cantrip'
-        } else {
-            scaling.mode = 'level'
-            if (spellInfos.spellhldie.current.indexOf('.') >= 0) {
-                var constant = parseFloat(spellInfos.spellhldie.current)
-                var formulaMult = Math.round(1 / constant)
-                scaling.formula = 'floor((@item.level - 1)/' + formulaMult + ')'+ spellInfos.spellhldietype.current
-            } else {
-                scaling.formula = spellInfos.spellhldie.current + spellInfos.spellhldietype.current
-            }
-        }
+function hasDamage(spellInfos) {
+    return spellInfos.spelldamage && spellInfos.spelldamage.current != '';
+}
 
+export function isHealingSpell(spellInfos) {
+    return spellInfos.spellhealing && spellInfos.spellhealing.current != '';
+}
+
+export function getScaling(spellInfos) {
+    var scaling = {
+        mode: '',
+        formula: ''
+    }
+
+    if (!spellInfos.spelllevel) {
         return scaling
     }
 
-    export function getComponents(spellInfos) {
-        var component = {
-            vocal: spellInfos.spellcomp_v.current.length > 0,
-            somatic: spellInfos.spellcomp_s.current.length > 0,
-            material: spellInfos.spellcomp_m.current.length > 0,
-            ritual: spellInfos.spellritual.current.length > 0,
-            concentration: spellInfos.spellconcentration.current.length > 0,
-            value: spellInfos.spellcomp_materials.current
+    if (spellInfos.spelllevel.current == 'cantrip') {
+        scaling.mode = 'cantrip'
+    } else {
+        scaling.mode = 'level'
+        if (spellInfos.spellhldie.current.indexOf('.') >= 0) {
+            var constant = parseFloat(spellInfos.spellhldie.current)
+            var formulaMult = Math.round(1 / constant)
+            scaling.formula = 'floor((@item.level - 1)/' + formulaMult + ')' + spellInfos.spellhldietype.current
+        } else {
+            scaling.formula = spellInfos.spellhldie.current + spellInfos.spellhldietype.current
         }
-
-        return component
     }
 
-    export function getMaterials(spellInfos) {
-        var materials = {
-            consumed: false,
-            cost: 0,
-            supply: 0,
-            value: spellInfos.spellcomp_materials.current
-        }
-        
-        return materials
+    return scaling
+}
+
+export function getComponents(spellInfos) {
+    var component = {
+        vocal: spellInfos.spellcomp_v && spellInfos.spellcomp_v.current.length > 0,
+        somatic: spellInfos.spellcomp_s && spellInfos.spellcomp_s.current.length > 0,
+        material: spellInfos.spellcomp_m && spellInfos.spellcomp_m.current.length > 0,
+        ritual: spellInfos.spellritual && spellInfos.spellritual.current.length > 0,
+        concentration: spellInfos.spellconcentration && spellInfos.spellconcentration.current.length > 0,
+        value: spellInfos.spellcomp_materials ? spellInfos.spellcomp_materials.current : ''
     }
 
-    export function getSave(spellInfos) {
-        var save = {
-            ability: moduleLib.ABILITIES[spellInfos.spellsave.current],
+    return component
+}
+
+export function getMaterials(spellInfos) {
+    var materials = {
+        consumed: false,
+        cost: 0,
+        supply: 0,
+        value: spellInfos.spellcomp_materials ? spellInfos.spellcomp_materials.current : 0
+    }
+
+    return materials
+}
+
+export function getSave(spellInfos) {
+    if (!spellInfos.spellsave) {
+        return {
+            ability: null,
             dc: null,
-            scaling: spellInfos.spell_ability.current
+            scaling: null
         }
+    }
+    return {
+        ability: moduleLib.ABILITIES[spellInfos.spellsave.current],
+        dc: null,
+        scaling: spellInfos.spell_ability.current
+    }
+}
 
-        return save
+export function getSpellSchool(spellInfos) {
+    return moduleLib.SPELL_SCHOOLS[spellInfos.spellschool.current]
+}
+
+export function isPactMagic(spellInfos) {
+    return spellInfos.spellclass ? spellInfos.spellclass.current.toLowerCase().indexOf('warlock') >= 0 : false;
+}
+
+export function getPreparation(spellInfos) {
+    var preparation = {
+        mode: 'prepared',
+        prepared: false
     }
 
-    export function getSpellSchool(spellInfos) {
-        return moduleLib.SPELL_SCHOOLS[spellInfos.spellschool.current]
+    if (this.isPactMagic(spellInfos) && spellInfos.spelllevel.current != 'cantrip') {
+        preparation = {
+            mode: 'pact',
+            prepared: true
+        }
     }
 
-    export function isPactMagic(spellInfos) {
-        return spellInfos.spellclass.current.toLowerCase().indexOf('warlock') >= 0;
+    if (spellInfos.innate && spellInfos.innate.current.length > 0) {
+        preparation = {
+            mode: 'innate',
+            prepared: true
+        }
     }
 
-    export function getPreparation(spellInfos) {
-        var preparation = {
-            mode: 'prepared',
-            prepared: false
-        }
+    return preparation
+}
 
-        if (this.isPactMagic(spellInfos) && spellInfos.spelllevel.current != 'cantrip') {
-            preparation = {
-                mode: 'pact',
-                prepared: true
-            }
-        }
+export function getIcon(spellInfos) {
+    var icon = 'icons/magic/symbols/ring-circle-smoke-blue.webp'
 
-        if (spellInfos.innate && spellInfos.innate.current.length > 0) {
-            preparation = {
-                mode: 'innate',
-                prepared: true
-            }
+    if (this.isHealingSpell(spellInfos)) {
+        return 'icons/magic/life/cross-worn-green.webp'
+    }
+    if (hasDamage(spellInfos)) {
+        var result = SPELL_ICONS_BY_TYPE[spellInfos.spelldamagetype.current.toLowerCase()]
+        if (result) {
+            return result
         }
-
-        return preparation
     }
 
-export {getSpellTarget, getSpellRange, getSpellDuration}
+    return icon
+}
+
+const SPELL_ICONS_BY_TYPE = {
+    'fire': 'icons/magic/fire/projectile-fireball-embers-yellow.webp',
+    'acid': 'icons/magic/acid/pouring-gas-smoke-liquid.webp',
+    'cold': 'icons/magic/water/barrier-ice-crystal-wall-faceted.webp',
+    'force': 'icons/magic/sonic/explosion-impact-shock-wave.webp',
+    'lightning': 'icons/magic/lightning/bolt-beam-strike-blue.webp',
+    'necrotic': 'icons/magic/unholy/strike-hand-glow-pink.webp',
+    'poison': 'icons/magic/acid/dissolve-bone-skull.webp',
+}
+
+export { getSpellTarget, getSpellRange, getSpellDuration }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -110,8 +110,8 @@ function journalShowFilePicker(event) {
             }
         },
         default: "two",
-        render: html => console.log("Register interactivity in the rendered dialog"),
-        close: html => console.log("Cancel")
+        render: html => vttLog("Register interactivity in the rendered dialog"),
+        close: html => vttLog("Cancel")
     })
     dialog.render(true)
 }
@@ -150,8 +150,8 @@ async function actorShowFilePicker(event) {
             }
         },
         default: "two",
-        render: html => console.log("Register interactivity in the rendered dialog"),
-        close: html => console.log("Cancel")
+        render: html => vttLog("Register interactivity in the rendered dialog"),
+        close: html => vttLog("Closing")
     })
     dialog.render(true)
 }


### PR DESCRIPTION
- Spell recreation
  - Spells with no casting time set will be ignored for the moment
- Renaming convention using parenthesis (eg. "King's Sword (longsword +2)" will look for "longsword +2" in compendiums)
- Added default icons for spells & features recreated from scratch
- Various bug fixes such as
  - not taking into account items with no name set